### PR TITLE
Shred `where` clauses into its constituent conjuncts in order to share them.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Rematch2"
 uuid = "351a7294-9038-49b6-b9cf-e076b05af63f"
 authors = ["RelationalAI"]
-version = "0.2.1"
+version = "0.2.3"
 
 [deps]
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
@@ -9,9 +9,3 @@ MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 [compat]
 MacroTools = "0.4, 0.5"
 julia = "1.5"
-
-[extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[targets]
-test = ["Test"]

--- a/src/BindPattern.jl
+++ b/src/BindPattern.jl
@@ -25,6 +25,9 @@ struct BinderState
     # A dictionary used to intern CodePoint values in Match2Cases.
     intern::Dict
 
+    # A counter used to dispense unique integers to make prettier gensyms
+    gensyms::Vector{Symbol}
+
     function BinderState(mod::Module, input_variable::Symbol)
         new(
             mod,
@@ -32,19 +35,83 @@ struct BinderState
             Dict{BoundFetchPattern, Symbol}(),
             Vector{Pair{LineNumberNode, String}}(),
             Vector{Any}(),
-            Dict()
+            Dict(),
+            Symbol[]
         )
     end
 end
 
-function get_temp(state::BinderState, p::BoundFetchPattern)
-    get!(gensym, state.assignments, p)
+function gensym(base::String, state::BinderState)::Symbol
+    s = gensym("$(base)_$(length(state.gensyms))")
+    push!(state.gensyms, s)
+    s
 end
-function get_temp(state::BinderState, p::BoundFetchBindingPattern)
-    get!(() -> get_temp(state, p.variable), state.assignments, p)
+gensym(base::String) = Base.gensym(base)
+
+#
+# Generate a fresh synthetic variable whose name hints at its purpose.
+#
+function gentemp(p::BoundFetchPattern)
+    error("not implemented: gentemp(::$(typeof(p)))")
+end
+function gentemp(p::BoundFetchFieldPattern)
+    gensym(string(simple_name(p.input), ".", p.field_name))
+end
+function gentemp(p::BoundFetchIndexPattern)
+    gensym(string(simple_name(p.input), "[", p.index, "]"))
+end
+function gentemp(p::BoundFetchRangePattern)
+    gensym(string(simple_name(p.input), "[", p.first_index, ":(length-", p.from_end, ")]"))
+end
+function gentemp(p::BoundFetchLengthPattern)
+    gensym(string("length(", simple_name(p.input), ")"))
+end
+
+#
+# Get the "base" name of a symbol (remove synthetic ## additions)
+#
+function simple_name(s::Symbol)
+    simple_name(string(s))
+end
+function simple_name(n::String)
+    if startswith(n, "##")
+        n1 = n[3:length(n)]
+        last = findlast('#', n1)
+        (last isa Int) ? n1[1:(last-1)] : n1
+    else
+        n
+    end
+end
+
+#
+# The following are special bindings used to handle the point where
+# a disjunction merges when and two sides have different bindings.
+# In dataflow-analysis terms, this is represented by a phi function.
+# This is a synthetic variable to hold the value that should be used
+# to hold the value after the merge point.
+#
+const phi_prefix = "saved_"
+is_phi(s::Symbol) = startswith(simple_name(s), phi_prefix)
+function get_temp(state::BinderState, p::BoundFetchPattern)
+    get!(() -> gentemp(p), state.assignments, p)
+end
+function get_temp(state::BinderState, p::BoundFetchExpressionPattern)
+    get!(state.assignments, p) do
+        if p.key isa Symbol
+            sym = get_temp(state, p.key)
+            @assert is_phi(sym)
+        else
+            sym = gensym("where", state)
+        end
+        sym
+    end
 end
 function get_temp(state::BinderState, p::Symbol)
-    get!(() -> gensym(string("saved_", p)), state.assignments, p)
+    get!(state.assignments, p) do
+        sym = gensym(string(phi_prefix, p), state)
+        @assert is_phi(sym)
+        sym
+    end
 end
 
 # We restrict the struct pattern to require something that looks like
@@ -187,11 +254,11 @@ function bind_pattern!(
             else
                 temp = get_temp(state, key)
                 if v1 != temp
-                    save = BoundFetchBindingPattern(location, source, v1, key)
+                    save = BoundFetchExpressionPattern(location, source, v1, ImmutableDict(key => v1), key)
                     bp1 = BoundAndPattern(location, source, BoundPattern[bp1, save])
                 end
                 if v2 != temp
-                    save = BoundFetchBindingPattern(location, source, v2, key)
+                    save = BoundFetchExpressionPattern(location, source, v2, ImmutableDict(key => v2), key)
                     bp2 = BoundAndPattern(location, source, BoundPattern[bp2, save])
                 end
                 assigned = ImmutableDict{Symbol, Symbol}(assigned, key, temp)
@@ -262,7 +329,7 @@ function bind_pattern!(
         # guard
         pattern0, assigned = bind_pattern!(location, subpattern, input, state, assigned)
         guard0, assigned0 = subst_patvars(guard, assigned)
-        pattern1 = BoundWhereTestPattern(location, guard, guard0, assigned0)
+        pattern1 = shred_where_clause(guard, false, location, state, assigned)
         pattern = BoundAndPattern(location, source, BoundPattern[pattern0, pattern1])
 
     else
@@ -318,7 +385,37 @@ function infer_fieldnames(type::Type, len::Int, match_positionally::Bool, locati
         error("$(location.file):$(location.line): Cannot infer which $len of the $(length(members)) fields to match from any positional constructor for `$type`.")
     end
 end
+
 dropfirst(a) = a[2:length(a)]
+
+# Shred a `where` clause into its component parts, conjunct by conjunct.  If necessary,
+# we push negation operators down.  This permits us to share the parts of a where clause
+# between different rules.
+#
+function shred_where_clause(
+    guard::Any,
+    inverted::Bool,
+    location::LineNumberNode,
+    state::BinderState,
+    assigned::ImmutableDict{Symbol, Symbol})::BoundPattern
+    if @capture(guard, !g_)
+        return shred_where_clause(g, !inverted, location, state, assigned)
+    elseif @capture(guard, g1_ && g2_) || @capture(guard, g1_ || g2_)
+        left = shred_where_clause(g1, inverted, location, state, assigned)
+        right = shred_where_clause(g2, inverted, location, state, assigned)
+        # DeMorgan's law:
+        #     `!(a && b)` => `!a || !b`
+        #     `!(a || b)` => `!a && !b`
+        result_type = (inverted == (guard.head == :&&)) ? BoundOrPattern : BoundAndPattern
+        return result_type(location, guard, BoundPattern[left, right])
+    else
+        (guard0, assigned0) = subst_patvars(guard, assigned)
+        fetch = BoundFetchExpressionPattern(location, guard, guard0, assigned0)
+        temp = get_temp(state, fetch)
+        test = BoundWhereTestPattern(location, guard, temp, inverted)
+        return BoundAndPattern(location, guard, BoundPattern[fetch, test])
+    end
+end
 
 #
 # Replace each pattern variable reference with the temporary variable holding the

--- a/src/LowerPattern.jl
+++ b/src/LowerPattern.jl
@@ -19,7 +19,7 @@ function code(bound_pattern::BoundRelationalTestPattern, state::BinderState)
     :($(bound_pattern.relation)($(bound_pattern.input), $(bound_pattern.value)))
 end
 function code(bound_pattern::BoundWhereTestPattern, state::BinderState)
-    bound_pattern.value
+    bound_pattern.inverted ? :(!$(bound_pattern.input)) : bound_pattern.input
 end
 function code(bound_pattern::BoundTypeTestPattern, state::BinderState)
     # We assert that the type is invariant.  Because this mutates state.assertions,
@@ -70,9 +70,9 @@ function code(bound_pattern::BoundFetchLengthPattern, state::BinderState)
     tempvar = state.assignments[bound_pattern]
     :($tempvar = $length($(bound_pattern.input)))
 end
-function code(bound_pattern::BoundFetchBindingPattern, state::BinderState)
+function code(bound_pattern::BoundFetchExpressionPattern, state::BinderState)
     tempvar = get_temp(state, bound_pattern)
-    :($tempvar = $(bound_pattern.input))
+    :($tempvar = $(bound_pattern.value))
 end
 
 # Return an expression that computes whether or not the pattern matches.

--- a/src/Match.jl
+++ b/src/Match.jl
@@ -66,6 +66,8 @@ Usage:
 
 Return `result` for the first matching `pattern`.
 If there are no matches, throw `MatchFailure`.
+This uses a brute-force code gen strategy, like using a series of if-else statements.
+It is used for testing purposes, as a reference for correct semantics.
 """
 macro match(value, cases)
     handle_match_cases(__source__, __module__, value, cases)

--- a/src/Match2Cases.jl
+++ b/src/Match2Cases.jl
@@ -91,7 +91,6 @@ pretty(io::IO, p::BoundEqualValueTestPattern) = print(io, p.input, " == ", p.val
 pretty(io::IO, p::BoundRelationalTestPattern) = print(io, p.input, " ", p.relation, " ", p.value)
 function pretty(io::IO, p::BoundWhereTestPattern)
     print(io, "where ")
-    isempty(p.assigned) || pretty(io, p.assigned)
     print(io, p.source)
 end
 pretty(io::IO, p::BoundTypeTestPattern) = print(io, p.input, " isa ", p.type)

--- a/test/rematch2.jl
+++ b/test/rematch2.jl
@@ -164,6 +164,64 @@ end
     end) == 7
 end
 
+@testset "test for sharing where clause conjuncts" begin
+    # State 1 TEST «input_value» isa Main.TempC.Foo ELSE: State 20 («label_2»)
+    # State 2 FETCH «input_value.x» := «input_value».x
+    # State 3 FETCH «input_value.y» := «input_value».y
+    # State 4 TEST «input_value.y» == 2 ELSE: State 11 («label_3»)
+    # State 5 FETCH «where_0» := (f1)((identity)(«input_value.x»))
+    # State 6 TEST where «where_0» ELSE: State 8 («label_5»)
+    # State 7 MATCH 1 with value 1
+    # State 8 («label_5») TEST «input_value.x» == 1 ELSE: State 20 («label_2»)
+    # State 9 FETCH «where_1» := (f2)((identity)(«input_value.y»))
+    # State 10 TEST where «where_1» THEN: State 14 («label_6») ELSE: State 20 («label_2»)
+    # State 11 («label_3») TEST «input_value.x» == 1 ELSE: State 15 («label_4»)
+    # State 12 FETCH «where_1» := (f2)((identity)(«input_value.y»))
+    # State 13 TEST where «where_1» ELSE: State 20 («label_2»)
+    # State 14 («label_6») MATCH 2 with value 2
+    # State 15 («label_4») FETCH «where_0» := (f1)((identity)(«input_value.x»))
+    # State 16 TEST where «where_0» ELSE: State 20 («label_2»)
+    # State 17 FETCH «where_1» := (f2)((identity)(«input_value.y»))
+    # State 18 TEST where «where_1» ELSE: State 20 («label_2»)
+    # State 19 MATCH 3 with value 3
+    # State 20 («label_2») MATCH 4 with value 4
+    @test (Rematch2.@match2_count_states some_value begin
+        Foo(x, 2) where f1(x)            => 1
+        Foo(1, y) where f2(y)            => 2
+        Foo(x, y) where (f1(x) && f2(y)) => 3
+        _                                => 4
+    end) == 20
+end
+
+@testset "test for sharing where clause disjuncts" begin
+    # State 1 TEST «input_value» isa Main.TempC.Foo ELSE: State 20 («label_2»)
+    # State 2 FETCH «input_value.x» := «input_value».x
+    # State 3 FETCH «input_value.y» := «input_value».y
+    # State 4 TEST «input_value.y» == 2 ELSE: State 11 («label_3»)
+    # State 5 FETCH «where_0» := (f1)((identity)(«input_value.x»))
+    # State 6 TEST where !«where_0» ELSE: State 8 («label_5»)
+    # State 7 MATCH 1 with value 1
+    # State 8 («label_5») TEST «input_value.x» == 1 ELSE: State 20 («label_2»)
+    # State 9 FETCH «where_1» := (f2)((identity)(«input_value.y»))
+    # State 10 TEST where !«where_1» THEN: State 14 («label_6») ELSE: State 20 («label_2»)
+    # State 11 («label_3») TEST «input_value.x» == 1 ELSE: State 15 («label_4»)
+    # State 12 FETCH «where_1» := (f2)((identity)(«input_value.y»))
+    # State 13 TEST where !«where_1» ELSE: State 20 («label_2»)
+    # State 14 («label_6») MATCH 2 with value 2
+    # State 15 («label_4») FETCH «where_0» := (f1)((identity)(«input_value.x»))
+    # State 16 TEST where !«where_0» ELSE: State 20 («label_2»)
+    # State 17 FETCH «where_1» := (f2)((identity)(«input_value.y»))
+    # State 18 TEST where !«where_1» ELSE: State 20 («label_2»)
+    # State 19 MATCH 3 with value 3
+    # State 20 («label_2») MATCH 4 with value 5
+    @test (Rematch2.@match2_count_states some_value begin
+        Foo(x, 2) where !f1(x)            => 1
+        Foo(1, y) where !f2(y)            => 2
+        Foo(x, y) where !(f1(x) || f2(y)) => 3
+        _                                 => 5
+    end) == 20
+end
+
 file = Symbol(@__FILE__)
 
 @testset "infer positional parameters from constructors 1" begin

--- a/test/rematch2.jl
+++ b/test/rematch2.jl
@@ -291,6 +291,17 @@ end
     end) == 20
 end
 
+@testset "exercise the dumping code for coverage" begin
+    io = IOBuffer()
+    Rematch2.@match2_dump_states io some_value begin
+        Foo(x, 2) where !f1(x)            => 1
+        Foo(1, y) where !f2(y)            => 2
+        Foo(x, y) where !(f1(x) || f2(y)) => 3
+        _                                 => 5
+    end
+    @test true
+end
+
 @testset "test for correct semantics of complex where clauses" begin
     function f1(a, b, c, d, e, f, g, h)
         @match2 (a, b, c, d, e, f, g, h) begin


### PR DESCRIPTION
Shred where clauses into its constituent parts in order to share them.

Specifically, we look through `!`, `&&`, and `||` operators and
cache the values of the elements during pattern-matching so they
can be shared among different rules.

* Shred `where a && b` into `where a && where b` so that `a` and `b` can be shared across patterns separately.
* Shred `where a || b` into `where a || where b` so that `a` and `b` can be shared across patterns separately.
* Use DeMorgan's law to push `!` down through `&&` and `||`.
* Tests demonstrate that each conjunct can be shared separately.
* Rename `BoundFetchBindingPattern` to `BoundFetchExpressionPattern` to permit it to capture an arbitrary expression.  Then, we use it to capture the value computed for a `where` clause.
* Introduced a naming scheme for temp variables so we can tell when they represent phi functions, which cannot be used across patterns.

**This is a simplified version of #23 for review purposes.**
The refactoring originally in this PR will be placed into a separate PR.

Fixes #24
Fixes #25