### PR TITLE
Track the type of fields when they are fetched.

### DIFF
--- a/src/BoundPattern.jl
+++ b/src/BoundPattern.jl
@@ -238,6 +238,7 @@ struct BoundFetchFieldPattern <: BoundFetchPattern
     source::Any
     input::Symbol
     field_name::Symbol
+    type::Type
 end
 # For the purposes of whether or not two fetches are the same: if they are fetching
 # the same field name (from the same input), then yes.
@@ -261,6 +262,7 @@ struct BoundFetchIndexPattern <: BoundFetchPattern
     input::Symbol
     # index value.  If negative, it is from the end.  `-1` accesses the last element
     index::Int
+    type::Type
 end
 function Base.hash(a::BoundFetchIndexPattern, h::UInt64)
     hash((a.input, a.index, 0x820a6d07cc13ac86), h)
@@ -280,6 +282,7 @@ struct BoundFetchRangePattern <: BoundFetchPattern
     input::Symbol
     first_index::Int # first index to include
     from_end::Int    # distance from the end for the last included index; 0 to include the last element
+    type::Type
 end
 function Base.hash(a::BoundFetchRangePattern, h::UInt64)
     hash((a.input, a.first_index, a.from_end, 0x7aea7756428a1646), h)
@@ -297,6 +300,7 @@ struct BoundFetchLengthPattern <: BoundFetchPattern
     location::LineNumberNode
     source::Any
     input::Symbol
+    type::Type
 end
 function Base.hash(a::BoundFetchLengthPattern, h::UInt64)
     hash((a.input, 0xa7167fae5a24c457), h)
@@ -325,6 +329,7 @@ struct BoundFetchExpressionPattern <: BoundFetchPattern
     value::Any    # value to be  preserved, e.g. previous binding of a variable
     assigned::ImmutableDict{Symbol, Symbol}
     key::Union{Nothing, Symbol}   # key to identify the temp, or user variable to be preserved
+    type::Type
 end
 function Base.hash(a::BoundFetchExpressionPattern, h::UInt64)
     hash((a.value, a.key, 0x53f0f6a137a891d8), h)


### PR DESCRIPTION
* Track the type of fields when they are fetched.
* Track the type of the input if it is a `::` expression
* Use the tracked types to infer the result of some type tests
* Exploit the fact that there are only two possible values of Bool.
* Tests for the above.

Fixes #22
Though there are further opportunities for tracking more types
in the future, for example the result of indexing operations.