### PR TITLE
Move toward compatibility with `Match.jl` in prep for merging.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ Manifest.toml
 /docs/Manifest.toml
 /tmp/*
 .vscode
+.DS_Store
+._*

--- a/src/BindPattern.jl
+++ b/src/BindPattern.jl
@@ -106,9 +106,9 @@ function simple_name(s::Symbol)
 end
 function simple_name(n::String)
     @assert startswith(n, "##")
-    n1 = n[3:length(n)]
+    n1 = n[3:end]
     last = findlast('#', n1)
-    (last isa Int) ? n1[1:(last-1)] : n1
+    isnothing(last) ? n1 : n1[1:prevind(n1, last)]
 end
 
 #
@@ -550,7 +550,7 @@ function bind_case(
             # expand top-level macros only
             case = macroexpand(binder.mod, case, recursive=false)
 
-        elseif is_expr(case, :tuple, 2) && is_case(case.args[2]) && is_expr(case.args[2].args[2], :if)
+        elseif is_expr(case, :tuple, 2) && is_case(case.args[2]) && is_expr(case.args[2].args[2], :if, 2)
             # rewrite `pattern, if guard end => result`, which parses as
             # `pattern, (if guard end => result)`
             # to `(pattern, if guard end) => result`
@@ -564,7 +564,7 @@ function bind_case(
             # rewrite `(pattern, if guard end) => result`
             # to `(pattern where guard) => result`
             pattern = case.args[2]
-            if is_expr(pattern, :tuple, 2) && is_expr(pattern.args[2], :if)
+            if is_expr(pattern, :tuple, 2) && is_expr(pattern.args[2], :if, 2)
                 if_guard = pattern.args[2]
                 if !is_empty_block(if_guard.args[2])
                     error("$(location.file):$(location.line): Unrecognized @match guard syntax: `$if_guard`.")

--- a/src/BindPattern.jl
+++ b/src/BindPattern.jl
@@ -1,12 +1,8 @@
-using Base: is_expr
-
-#
 #
 # Persistent data that we use across different patterns, to ensure the same computations
 # are always represented by the same synthetic variables.  We use this during lowering
 # and also during code generation, since it holds some of the context required during code
 # generation (such as assertions and assignments)
-#
 #
 struct BinderContext
     # The module containing the pattern, in which types appearing in the
@@ -109,13 +105,10 @@ function simple_name(s::Symbol)
     simple_name(string(s))
 end
 function simple_name(n::String)
-    if startswith(n, "##")
-        n1 = n[3:length(n)]
-        last = findlast('#', n1)
-        (last isa Int) ? n1[1:(last-1)] : n1
-    else
-        n
-    end
+    @assert startswith(n, "##")
+    n1 = n[3:length(n)]
+    last = findlast('#', n1)
+    (last isa Int) ? n1[1:(last-1)] : n1
 end
 
 #
@@ -263,8 +256,7 @@ function bind_pattern!(
         T = source.args[1]
         subpatterns = source.args[2:length(source.args)]
         len = length(subpatterns)
-        named_fields = [pat.args[1] for pat in subpatterns
-                                    if (pat isa Expr) && pat.head == :kw]
+        named_fields = [pat.args[1] for pat in subpatterns if is_expr(pat, :kw)]
         named_count = length(named_fields)
         if named_count != length(unique(named_fields))
             error("$(location.file):$(location.line): Pattern `$source` has duplicate " *
@@ -400,7 +392,7 @@ function bind_pattern!(
 
         seen_splat = false
         for (i, subpattern) in enumerate(subpatterns)
-            if subpattern isa Expr && subpattern.head == :...
+            if is_expr(subpattern, :...)
                 @assert length(subpattern.args) == 1
                 @assert !seen_splat
                 seen_splat = true
@@ -444,7 +436,7 @@ end
 function split_where(T, location)
     type = T
     where_clause = nothing
-    while type isa Expr && type.head == :where
+    while is_expr(type, :where)
         where_clause = (where_clause === nothing) ? type.args[2] : :($(type.args[2]) && $where_clause)
         type = type.args[1]
     end
@@ -539,4 +531,70 @@ function bind_expression(location::LineNumberNode, expr, assigned::ImmutableDict
     end
 
     return BoundExpression(location, expr, new_assigned)
+end
+
+is_empty_block(x) = is_expr(x, :block) && all(a -> a isa LineNumberNode, x.args)
+
+#
+# Bind a case.
+#
+function bind_case(
+    case_number::Int,
+    location::LineNumberNode,
+    case,
+    predeclared_temps,
+    binder::BinderContext)::BoundCase
+    while true
+        # do some rewritings if needed
+        if is_expr(case, :macrocall)
+            # expand top-level macros only
+            case = macroexpand(binder.mod, case, recursive=false)
+
+        elseif is_expr(case, :tuple, 2) && is_case(case.args[2]) && is_expr(case.args[2].args[2], :if)
+            # rewrite `pattern, if guard end => result`, which parses as
+            # `pattern, (if guard end => result)`
+            # to `(pattern, if guard end) => result`
+            # so that the guard is part of the pattern.
+            pattern = case.args[1]
+            if_guard = case.args[2].args[2]
+            result = case.args[2].args[3]
+            case = :(($pattern, $if_guard) => $result)
+
+        elseif is_case(case)
+            # rewrite `(pattern, if guard end) => result`
+            # to `(pattern where guard) => result`
+            pattern = case.args[2]
+            if is_expr(pattern, :tuple, 2) && is_expr(pattern.args[2], :if)
+                if_guard = pattern.args[2]
+                if !is_empty_block(if_guard.args[2])
+                    error("$(location.file):$(location.line): Unrecognized @match guard syntax: `$if_guard`.")
+                end
+                pattern = pattern.args[1]
+                guard = if_guard.args[1]
+                result = case.args[3]
+                case = :(($pattern where $guard) => $result)
+            end
+            break
+
+        else
+            error("$(location.file):$(location.line): Unrecognized @match case syntax: `$case`.")
+        end
+    end
+
+    @assert is_case(case)
+    pattern = case.args[2]
+    result = case.args[3]
+    (pattern, result) = adjust_case_for_return_macro(binder.mod, location, pattern, result, predeclared_temps)
+    bound_pattern, assigned = bind_pattern!(
+        location, pattern, binder.input_variable, binder, ImmutableDict{Symbol, Symbol}())
+    result_expression = bind_expression(location, result, assigned)
+    return BoundCase(case_number, location, pattern, bound_pattern, result_expression)
+end
+
+function pretty(io::IO, case::BoundCase, binder::BinderContext)
+    print(io, case.case_number, ": ")
+    pretty(io, case.pattern, binder)
+    print(io, " => ")
+    pretty(io, case.result_expression)
+    println(io)
 end

--- a/src/BoundPattern.jl
+++ b/src/BoundPattern.jl
@@ -78,16 +78,20 @@ loc(p::BoundExpression) = p.location
 source(p::BoundExpression) = p.source
 function pretty(io::IO, e::BoundExpression)
     if !isempty(e.assignments)
-        print(io, "[")
-        for (i, (k, v)) in enumerate(e.assignments)
-            i > 1 && print(io, ", ")
-            pretty(io, k)
-            print(io, " => ")
-            pretty(io, v)
-        end
-        print(io, "] ")
+        pretty(io, e.assignments)
+        print(io, " ")
     end
     pretty(io, e.source)
+end
+function pretty(io::IO, assignments::ImmutableDict{Symbol, Symbol})
+    print(io, "[")
+    for (i, (k, v)) in enumerate(assignments)
+        i > 1 && print(io, ", ")
+        pretty(io, k)
+        print(io, " => ")
+        pretty(io, v)
+    end
+    print(io, "]")
 end
 function code(e::BoundExpression)
     value = Expr(:block, e.location, e.source)
@@ -210,7 +214,6 @@ struct BoundOrPattern <: BoundPattern
     end
 end
 Base.hash(a::BoundOrPattern, h::UInt64) = hash(a._cached_hash, h)
-Base.hash(a::BoundOrPattern) = a._cached_hash
 function Base.:(==)(a::BoundOrPattern, b::BoundOrPattern)
     a._cached_hash == b._cached_hash && a.subpatterns == b.subpatterns
 end
@@ -249,7 +252,6 @@ struct BoundAndPattern <: BoundPattern
     end
 end
 Base.hash(a::BoundAndPattern, h::UInt64) = hash(a._cached_hash, h)
-Base.hash(a::BoundAndPattern) = a._cached_hash
 function Base.:(==)(a::BoundAndPattern, b::BoundAndPattern)
     a._cached_hash == b._cached_hash && a.subpatterns == b.subpatterns
 end
@@ -388,3 +390,60 @@ is_refutable(pattern::BoundOrPattern) = all(is_refutable, pattern.subpatterns)
 
 # Pattern is definitely true
 is_irrefutable(pattern::BoundPattern) = !is_refutable(pattern)
+
+#
+# A data structure representing information about a single match case.
+# Initially, it represents just what was in source.  However, during construction of
+# the decision automaton, the pattern represents only the remaining operations that
+# must be performed to decide if the pattern matches.
+#
+struct BoundCase
+    # The index of the case, starting with 1 for the first => in the @match
+    case_number::Int
+
+    # Its location for error reporting purposes
+    location::LineNumberNode
+
+    # Its source for error reporting
+    pattern_source
+
+    # The operations (or remaining operations) required to perform the match.
+    # In a node of the decision automaton, some operations may have already been done,
+    # and they are removed from the bound pattern in subsequent nodes of the automaton.
+    # When the bound pattern is simply `true`, the case's pattern has matched.
+    pattern::BoundPattern
+
+    # The user's result expression for this case.
+    result_expression::BoundExpression
+
+    _cached_hash::UInt64
+    function BoundCase(
+        case_number::Int,
+        location::LineNumberNode,
+        pattern_source,
+        pattern::BoundPattern,
+        result_expression::BoundExpression)
+        _hash = hash((case_number, pattern, result_expression), 0x1cdd9657bfb1e645)
+        new(case_number, location, pattern_source, pattern, result_expression, _hash)
+    end
+end
+function with_pattern(
+    case::BoundCase,
+    new_pattern::BoundPattern)
+    BoundCase(
+        case.case_number,
+        case.location,
+        case.pattern_source,
+        new_pattern,
+        case.result_expression)
+end
+function Base.hash(case::BoundCase, h::UInt64)
+    hash(case._cached_hash, h)
+end
+function Base.:(==)(a::BoundCase, b::BoundCase)
+    a._cached_hash == b._cached_hash &&
+    isequal(a.case_number, b.case_number) &&
+        isequal(a.pattern, b.pattern) &&
+        isequal(a.result_expression, b.result_expression)
+end
+loc(case::BoundCase) = case.location

--- a/src/BoundPattern.jl
+++ b/src/BoundPattern.jl
@@ -430,7 +430,7 @@ end
 function with_pattern(
     case::BoundCase,
     new_pattern::BoundPattern)
-    BoundCase(
+    return BoundCase(
         case.case_number,
         case.location,
         case.pattern_source,

--- a/src/Match.jl
+++ b/src/Match.jl
@@ -1,16 +1,20 @@
+#
+# Implementation of `@match pattern = value`
+#
 function handle_match_eq(location::LineNumberNode, mod::Module, expr)
     is_expr(expr, :(=), 2) ||
         error(string("Unrecognized @match syntax: ", expr))
     pattern = expr.args[1]
     value = expr.args[2]
-
     binder = BinderContext(mod)
     input_variable::Symbol = binder.input_variable
     (bound_pattern, assigned) = bind_pattern!(
         location, pattern, input_variable, binder, ImmutableDict{Symbol, Symbol}())
-
-    matched = lower_pattern_to_boolean(bound_pattern, binder)
+    simplified_pattern = simplify(bound_pattern, Set{Symbol}(values(assigned)), binder)
+    matched = lower_pattern_to_boolean(simplified_pattern, binder)
     q = Expr(:block,
+        location,
+
         # evaluate the assertions
         binder.assertions...,
 
@@ -20,12 +24,39 @@ function handle_match_eq(location::LineNumberNode, mod::Module, expr)
         # check that it matched the pattern; if not throw an exception
         :($matched || $throw($MatchFailure($input_variable))),
 
-        # assign to pattern variables.
+        # assign to pattern variables in the enclosing scope
         assignments(assigned)...,
 
         # finally, yield the input that was matched
-        input_variable)
+        input_variable
+    )
     esc(q)
+end
+
+#
+# Implementation of `@ismatch value pattern`
+#
+function handle_ismatch(location::LineNumberNode, mod::Module, value, pattern)
+    binder = BinderContext(mod)
+    input_variable::Symbol = binder.input_variable
+    bound_pattern, assigned = bind_pattern!(
+        location, pattern, input_variable, binder, ImmutableDict{Symbol, Symbol}())
+    simplified_pattern = simplify(bound_pattern, Set{Symbol}(values(assigned)), binder)
+    matched = lower_pattern_to_boolean(simplified_pattern, binder)
+    bindings = Expr(:block, assignments(assigned)..., true)
+    result = Expr(:block,
+        location,
+
+        # evaluate the assertions
+        binder.assertions...,
+
+        # compute the input into a variable so we do not repeat its side-effects
+        :($input_variable = $value),
+
+        # check that it matched the pattern; if so assign pattern variables
+        :($matched && $bindings)
+    )
+    esc(result)
 end
 
 """
@@ -141,4 +172,31 @@ Repeated variables only match if they are equal (`==`). For example `(x,x)` matc
 """
 macro match end
 
-export @match
+"""
+Usage:
+```
+    @ismatch value pattern
+```
+
+Return `true` if `value` matches `pattern`, `false` otherwise.  When returning `true`,
+binds the pattern variables in the enclosing scope.  Typically, it would be used like this:
+
+```
+    if @ismatch value pattern
+        # use the pattern variables
+    end
+```
+
+or
+
+```
+    if (@ismatch value pattern) && (some_other_condition)
+        # use the pattern variables
+    end
+```
+
+guarded patterns ought not be used with @ismatch, as you can just use `&&` instead.
+"""
+macro ismatch(value, pattern)
+    handle_ismatch(__source__, __module__, value, pattern)
+end

--- a/src/Match.jl
+++ b/src/Match.jl
@@ -182,16 +182,16 @@ Return `true` if `value` matches `pattern`, `false` otherwise.  When returning `
 binds the pattern variables in the enclosing scope.  Typically, it would be used like this:
 
 ```
-    if @ismatch value pattern
-        # use the pattern variables
+    if @ismatch point Point(0, y)
+        println("On the y axis at y = \$y")
     end
 ```
 
 or
 
 ```
-    if (@ismatch value pattern) && (some_other_condition)
-        # use the pattern variables
+    if (@ismatch point Point(x, y)) && x < y
+        println("The point (\$x, \$y) is in the upper left")
     end
 ```
 

--- a/src/Match2Cases.jl
+++ b/src/Match2Cases.jl
@@ -27,7 +27,7 @@ function build_automaton_core(
     # If the value had a type annotation, then we can use that to
     # narrow down the cases that we need to consider.
     input_type = Any
-    if is_expr(value, :(::)) && length(value.args) == 2
+    if is_expr(value, :(::), 2)
         type = value.args[2]
         try
             input_type = bind_type(location, type, binder.input_variable, binder)

--- a/src/Match2Cases.jl
+++ b/src/Match2Cases.jl
@@ -1,29 +1,4 @@
 #
-# Bind a case, producing a case partial result.
-#
-function bind_case(
-    case_number::Int,
-    location::LineNumberNode,
-    case,
-    predeclared_temps,
-    binder::BinderContext)::CasePartialResult
-    while case isa Expr && case.head == :macrocall
-        # expand top-level macros only
-        case = macroexpand(binder.mod, case, recursive=false)
-    end
-
-    is_expr(case, :call, 3) && case.args[1] == :(=>) ||
-        error("$(location.file):$(location.line): Unrecognized @match2 case syntax: `$case`.")
-    pattern = case.args[2]
-    result = case.args[3]
-    (pattern, result) = adjust_case_for_return_macro(binder.mod, location, pattern, result, predeclared_temps)
-    bound_pattern, assigned = bind_pattern!(
-        location, pattern, binder.input_variable, binder, ImmutableDict{Symbol, Symbol}())
-    result_expression = bind_expression(location, result, assigned)
-    return CasePartialResult(case_number, location, pattern, bound_pattern, result_expression)
-end
-
-#
 # Build the decision automaton and return its entry point.
 #
 function build_automaton_core(
@@ -32,12 +7,12 @@ function build_automaton_core(
     location::LineNumberNode,
     predeclared_temps,
     binder::BinderContext)::AutomatonNode
-    cases = CasePartialResult[]
+    cases = BoundCase[]
     for case in source_cases
         if case isa LineNumberNode
             location = case
         else
-            bound_case::CasePartialResult = bind_case(length(cases) + 1, location, case, predeclared_temps, binder)
+            bound_case::BoundCase = bind_case(length(cases) + 1, location, case, predeclared_temps, binder)
             bound_case = simplify(bound_case, binder)
             push!(cases, bound_case)
         end
@@ -52,7 +27,7 @@ function build_automaton_core(
     # If the value had a type annotation, then we can use that to
     # narrow down the cases that we need to consider.
     input_type = Any
-    if value isa Expr && value.head == :(::) && length(value.args) == 2
+    if is_expr(value, :(::)) && length(value.args) == 2
         type = value.args[2]
         try
             input_type = bind_type(location, type, binder.input_variable, binder)
@@ -75,7 +50,7 @@ function build_automaton_core(
             set_next!(node, binder)
             @assert node.action !== nothing
             @assert node.next !== nothing
-            if node.action isa CasePartialResult
+            if node.action isa BoundCase
                 push!(reachable, node.action.case_number)
             end
             union!(work_queue, successors(node))
@@ -120,7 +95,7 @@ function generate_code(top_down_nodes::Vector{DeduplicatedAutomatonNode}, @nospe
             push!(emit, :(@label $(labels[node])))
         end
         action = node.action
-        if action isa CasePartialResult
+        if action isa BoundCase
             # We've matched a pattern.
             push!(emit, loc(action))
             push!(emit, :($result_variable = $(code(action.result_expression))))
@@ -159,14 +134,14 @@ end
 # Build the whole decision automaton from the syntax for the value and body
 #
 function build_automaton(location::LineNumberNode, mod::Module, @nospecialize(value), body)
-    if body isa Expr && body.head == :call && body.args[1] == :(=>)
+    if is_case(body)
         # previous version of @match supports `@match(expr, pattern => value)`
         body = Expr(:block, body)
     end
-    if body isa Expr && body.head == :block
+    if is_expr(body, :block)
         source_cases = body.args
     else
-        error("$(location.file):$(location.line): Unrecognized @match2 block syntax: `$body`.")
+        error("$(location.file):$(location.line): Unrecognized @match block syntax: `$body`.")
     end
 
     binder = BinderContext(mod)
@@ -192,7 +167,7 @@ function set_next!(node::AutomatonNode, binder::BinderContext)
     @assert node.action === nothing
     @assert node.next === nothing
 
-    action::Union{CasePartialResult, BoundPattern, Expr} = next_action(node, binder)
+    action::Union{BoundCase, BoundPattern, Expr} = next_action(node, binder)
     next::Union{Tuple{}, Tuple{AutomatonNode}, Tuple{AutomatonNode, AutomatonNode}} =
         make_next(node, action, binder)
     node.action = action
@@ -214,7 +189,7 @@ end
 #
 function next_action(
     node::AutomatonNode,
-    binder::BinderContext)::Union{CasePartialResult, BoundPattern, Expr}
+    binder::BinderContext)::Union{BoundCase, BoundPattern, Expr}
     if isempty(node.cases)
         # cases have been exhausted.  Return code to throw a match failure.
         return :($throw($MatchFailure($(binder.input_variable))))
@@ -240,7 +215,7 @@ end
 #
 function make_next(
     node::AutomatonNode,
-    action::Union{CasePartialResult, Expr},
+    action::Union{BoundCase, Expr},
     binder::BinderContext)
     return ()
 end
@@ -293,10 +268,10 @@ function remove(action::BoundTestPattern, sense::Bool, node::AutomatonNode, bind
     return AutomatonNode(cases)
 end
 
-function remove(action::BoundTestPattern, action_result::Bool, case::CasePartialResult, binder::BinderContext)::CasePartialResult
+function remove(action::BoundTestPattern, action_result::Bool, case::BoundCase, binder::BinderContext)::BoundCase
     with_pattern(case, remove(action, action_result, case.pattern, binder))
 end
-function remove(action::BoundFetchPattern, case::CasePartialResult, binder::BinderContext)::CasePartialResult
+function remove(action::BoundFetchPattern, case::BoundCase, binder::BinderContext)::BoundCase
     with_pattern(case, remove(action, case.pattern, binder))
 end
 
@@ -358,11 +333,14 @@ function remove(action::BoundTypeTestPattern, action_result::Bool, pattern::Boun
         elseif pattern.type <: action.type
             # we are asking about a narrower type - result unknown
             return pattern
-        elseif typeintersect(pattern.type, action.type) == Base.Bottom
+        else
+            # Since Julia does not support multiple inheritance, if the two types
+            # are not related by inheritance, then no types that implement both will
+            # ever come into existence.
+            @assert typeintersect(pattern.type, action.type) == Base.Bottom
+
             # their intersection is empty, so it cannot be pattern.type
             return BoundFalsePattern(loc(pattern), source(pattern))
-        else
-            return pattern
         end
     else
         # the type test failed.
@@ -381,7 +359,7 @@ end
 #
 # Simplify a case by removing fetch operations whose results are not used.
 #
-function simplify(case::CasePartialResult, binder::BinderContext)::CasePartialResult
+function simplify(case::BoundCase, binder::BinderContext)::BoundCase
     required_temps = Set(values(case.result_expression.assignments))
     simplified_pattern = simplify(case.pattern, required_temps, binder)
     return with_pattern(case, simplified_pattern)
@@ -429,7 +407,8 @@ end
 function simplify(pattern::BoundAndPattern, required_temps::Set{Symbol}, binder::BinderContext)::BoundPattern
     subpatterns = BoundPattern[]
     for p in reverse(pattern.subpatterns)
-        push!(subpatterns, simplify(p, required_temps, binder))
+        simplified = simplify(p, required_temps, binder)
+        push!(subpatterns, simplified)
     end
     BoundAndPattern(loc(pattern), source(pattern), BoundPattern[reverse(subpatterns)...])
 end
@@ -497,6 +476,9 @@ end
 function handle_match2_cases(location::LineNumberNode, mod::Module, value, body)
     top_down_nodes, predeclared_temps, binder = build_deduplicated_automaton(location, mod, value, body)
     result = generate_code(top_down_nodes, value, location, binder)
+    @assert is_expr(result, :block)
+
+    # We use a `let` to ensure consistent closed scoping
     result = Expr(:let, Expr(:block, predeclared_temps...), result)
     esc(result)
 end

--- a/src/Rematch2.jl
+++ b/src/Rematch2.jl
@@ -19,9 +19,9 @@ macro _const(x)
     end
 end
 
-is_expr(e, head) = e isa Expr && e.head == head
-is_expr(e, head, n) = is_expr(e, head) && length(e.args) == n
-is_case(e) = is_expr(e, :call, 3) && e.args[1] == :(=>)
+is_expr(@nospecialize(e), head::Symbol) = e isa Expr && e.head == head
+is_expr(@nospecialize(e), head::Symbol, n::Int) = is_expr(e, head) && length(e.args) == n
+is_case(@nospecialize(e)) = is_expr(e, :call, 3) && e.args[1] == :(=>)
 
 include("TopologicalSort.jl")
 include("ImmutableVector.jl")

--- a/src/Rematch2.jl
+++ b/src/Rematch2.jl
@@ -1,6 +1,6 @@
 module Rematch2
 
-export @match, @match2, MatchFailure, @match_return, @match_fail
+export @match, @match2, MatchFailure, @match_return, @match_fail, @ismatch
 
 using MacroTools: MacroTools, @capture
 using Base.Iterators: reverse
@@ -18,6 +18,10 @@ macro _const(x)
         esc(x)
     end
 end
+
+is_expr(e, head) = e isa Expr && e.head == head
+is_expr(e, head, n) = is_expr(e, head) && length(e.args) == n
+is_case(e) = is_expr(e, :call, 3) && e.args[1] == :(=>)
 
 include("TopologicalSort.jl")
 include("ImmutableVector.jl")

--- a/test/coverage.jl
+++ b/test/coverage.jl
@@ -441,14 +441,29 @@ end # of automaton
         end) == 1
     end
 
+    @testset "Some unlikely code" begin
+        @test (@match2 1 begin
+            ::Int && ::Int => 1
+        end) == 1
+
+        @test_throws LoadError @eval (@match2 true begin
+            x::Bool, if x; true; end => 1
+        end)
+    end
+
     @testset "Some other normally unreachable code 1" begin
         f = Rematch2.BoundFalsePattern(LineNumberNode(@__LINE__, @__FILE__), false)
         @test_throws ErrorException Rematch2.next_action(f)
 
-        node = Rematch2.AutomatonNode(Rematch2.CasePartialResult[])
+        node = Rematch2.AutomatonNode(Rematch2.BoundCase[])
         pattern = Trash(LineNumberNode(@__LINE__, @__FILE__))
         binder = Rematch2.BinderContext(@__MODULE__)
         @test_throws ErrorException Rematch2.make_next(node, pattern, binder)
+
+        devnull = IOBuffer()
+        f = Rematch2.BoundFalsePattern(LineNumberNode(@__LINE__, @__FILE__), false)
+        Rematch2.pretty(devnull, f)
+        @test f == f
     end
 
     @testset "Abstract types" begin

--- a/test/rematch2.jl
+++ b/test/rematch2.jl
@@ -25,6 +25,20 @@ end
 
 @testset "@rematch2 tests" begin
 
+@testset "Check that `,if condition end` guards are parsed properly" begin
+    x = true
+    @test (@match2 3 begin
+        ::Int, if x end => 1
+        _ => 2
+    end) == 1
+
+    x = false
+    @test (@match2 3 begin
+        ::Int, if x end => 1
+        _ => 2
+    end) == 2
+end
+
 @testset "Check that `where` clauses are reparsed properly 1" begin
     x = true
     @test (@match2 3 begin
@@ -593,7 +607,7 @@ end
                 @test ex isa LoadError
                 e = ex.error
                 @test e isa ErrorException
-                @test e.msg == "$file:$line: Unrecognized @match2 block syntax: `b + c`."
+                @test e.msg == "$file:$line: Unrecognized @match block syntax: `b + c`."
             end
         end
     end
@@ -610,7 +624,7 @@ end
                 @test ex isa LoadError
                 e = ex.error
                 @test e isa ErrorException
-                @test startswith(e.msg, "$file:$line: Unrecognized @match2 case syntax: `2 + 2 =")
+                @test startswith(e.msg, "$file:$line: Unrecognized @match case syntax: `2 + 2 =")
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 module Rematch2Tests
 
-using Rematch2: @match, @match2, MatchFailure, Rematch2, @match_fail, @match_return
+using Rematch2
 using ReTest
 using Random
 using MacroTools: MacroTools
@@ -12,6 +12,7 @@ include("coverage.jl")
 include("nontrivial.jl")
 include("topological.jl")
 include("match_return.jl")
+include("test_ismatch.jl")
 
 retest(Rematch2Tests)
 

--- a/test/test_ismatch.jl
+++ b/test/test_ismatch.jl
@@ -1,0 +1,30 @@
+@testset "tests for the `@ismatch` macro" begin
+
+    @testset "simple @ismatch cases 1" begin
+
+        v = Foo(1, 2)
+        if @ismatch v Foo(x, y)
+            @test x == 1
+            @test y == 2
+        else
+            @test false
+        end
+        @test x == 1
+
+    end
+
+    @testset "simple @ismatch cases 2" begin
+
+        v = "something else"
+        if @ismatch v Foo(x, y)
+            @test false
+        else
+            @test !(@isdefined x)
+            @test !(@isdefined y)
+        end
+        @test !(@isdefined x)
+        @test !(@isdefined y)
+
+    end
+
+end


### PR DESCRIPTION
* Add support for `pattern, if condition end` guard syntax
* Add support for `@ismatch` macro
* Some reorganization to share code between macros:
    * Renamed `CasePartialResult` to `BoundCase` and use it in the `@match` macro simplified implementation.
    * Moved `BoundCase` to `BoundPattern.jl`
    * Moved `bind_case` to `BindPattern.jl`
* Added some slight optimizations to `@match pat = value`

Note that this PR builds on #61, so that one should be reviewed and merged before this one is merged.