### PR TITLE
Additional features for compat with Match.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Rematch2"
 uuid = "351a7294-9038-49b6-b9cf-e076b05af63f"
 authors = ["Neal Gafter <neal.gafter@relational.ai>"]
-version = "0.5.0"
+version = "0.6.0"
 
 [deps]
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"

--- a/src/BindPattern.jl
+++ b/src/BindPattern.jl
@@ -445,7 +445,7 @@ function bind_pattern!(
         lower = source.args[2]
         upper = source.args[3]
         if upper isa Expr || upper isa Symbol || lower isa Expr || lower isa Symbol
-            error("$(location.file):$(location.line): Unregognized pattern syntax `$(pretty(lower)):$(pretty(upper))`.")
+            error("$(location.file):$(location.line): Unregognized pattern syntax `($(pretty(lower))):($(pretty(upper)))`.")
         end
         pattern = BoundIsMatchTestPattern(input, BoundExpression(location, source), false)
 

--- a/src/BindPattern.jl
+++ b/src/BindPattern.jl
@@ -440,12 +440,15 @@ function bind_pattern!(
         pattern1 = shred_where_clause(guard, false, location, binder, assigned)
         pattern = BoundAndPattern(location, source, BoundPattern[pattern0, pattern1])
 
-    elseif is_expr(source, :call, 3) && source.args[1] == :(:)
+    elseif is_expr(source, :call) && source.args[1] == :(:) && length(source.args) in 3:4
         # A range pattern.  We depend on the Range API to make sense of it.
         lower = source.args[2]
         upper = source.args[3]
-        if upper isa Expr || upper isa Symbol || lower isa Expr || lower isa Symbol
-            error("$(location.file):$(location.line): Unregognized pattern syntax `($(pretty(lower))):($(pretty(upper)))`.")
+        step = (length(source.args) == 4) ? source.args[4] : nothing
+        if upper isa Expr || upper isa Symbol ||
+            lower isa Expr || lower isa Symbol ||
+            step isa Expr || step isa Symbol
+            error("$(location.file):$(location.line): Non-constant range pattern: `$source`.")
         end
         pattern = BoundIsMatchTestPattern(input, BoundExpression(location, source), false)
 

--- a/src/Match2Cases.jl
+++ b/src/Match2Cases.jl
@@ -290,8 +290,8 @@ end
 function remove(action::BoundTestPattern, action_result::Bool, pattern::BoundTestPattern, binder::BinderContext)::BoundPattern
     return (action == pattern) ? BoundBoolPattern(loc(pattern), source(pattern), action_result) : pattern
 end
-function remove(action::BoundEqualValueTestPattern, action_result::Bool, pattern::BoundEqualValueTestPattern, binder::BinderContext)::BoundPattern
-    if action.input != pattern.input
+function remove(action::BoundIsMatchTestPattern, action_result::Bool, pattern::BoundIsMatchTestPattern, binder::BinderContext)::BoundPattern
+    if action.input != pattern.input || action.force_equality != pattern.force_equality
         return pattern
     end
     if isequal(action.bound_expression, pattern.bound_expression)
@@ -397,7 +397,7 @@ function simplify(pattern::BoundFetchExpressionPattern, required_temps::Set{Symb
         BoundTruePattern(loc(pattern), source(pattern))
     end
 end
-function simplify(pattern::BoundEqualValueTestPattern, required_temps::Set{Symbol}, binder::BinderContext)::BoundPattern
+function simplify(pattern::BoundIsMatchTestPattern, required_temps::Set{Symbol}, binder::BinderContext)::BoundPattern
     push!(required_temps, pattern.input)
     for (v, t) in pattern.bound_expression.assignments
         push!(required_temps, t)

--- a/test/coverage.jl
+++ b/test/coverage.jl
@@ -31,100 +31,100 @@ end
 expected="""
 Decision Automaton: (57 nodes) input «input_value»
 Node 1
-  1: «input_value» == 1 => 1
-  2: («input_value» isa Main.Rematch2Tests.Foo && «input_value».x && «input_value».y && «input_value.y» == [x => «input_value.x»] x) => 2
+  1: @ismatch(1, «input_value») => 1
+  2: («input_value» isa Main.Rematch2Tests.Foo && «input_value.x» := «input_value».x && «input_value.y» := «input_value».y && isequal([x => «input_value.x»] x, «input_value.y»)) => 2
   3: «input_value» isa Main.Rematch2Tests.D => 3
-  4: («input_value» isa AbstractArray && length(«input_value») && «length(input_value)» >= 2 && «input_value»[2:(length(«input_value»)-1)]) => [y => «input_value[2:(length-1)]»] y
-  5: («input_value» isa Tuple && length(«input_value») && «length(input_value)» >= 2 && «input_value»[-1] && (e).q1 && «where_0») => [z => «input_value[-1]»] z
-  6: («input_value» == 6 || «input_value» == 7) => 6
-  7: («input_value» isa Main.Rematch2Tests.A && (e).q2 && «where_1») => 7
-  8: («input_value» isa Main.Rematch2Tests.B && (e).q3 && «where_2») => 8
-  9: («input_value» isa Main.Rematch2Tests.C && (e).q4 && «where_3») => 9
-  10: («input_value» isa Main.Rematch2Tests.Foo && «input_value».x && «input_value».y && «input_value.y» == 2 && [x => «input_value.x»] (f1)(x) && «where_4») => 1
-  11: («input_value» isa Main.Rematch2Tests.Foo && «input_value».x && «input_value.x» == 1 && «input_value».y && [y => «input_value.y»] (f2)(y) && «where_5») => 2
-  12: («input_value» isa Main.Rematch2Tests.Foo && «input_value».x && «input_value».y && [x => «input_value.x»] (f1)(x) && «where_4» && [y => «input_value.y»] (f2)(y) && «where_5») => 3
-    TEST «input_value» == 1
+  4: («input_value» isa AbstractArray && «length(input_value)» := length(«input_value») && «length(input_value)» >= 2 && «input_value[2:(length-1)]» := «input_value»[2:(length(«input_value»)-1)]) => [y => «input_value[2:(length-1)]»] y
+  5: («input_value» isa Tuple && «length(input_value)» := length(«input_value») && «length(input_value)» >= 2 && «input_value[-1]» := «input_value»[-1] && «where_0» := e.q1 && «where_0») => [z => «input_value[-1]»] z
+  6: (@ismatch(6, «input_value») || @ismatch(7, «input_value»)) => 6
+  7: («input_value» isa Main.Rematch2Tests.A && «where_1» := e.q2 && «where_1») => 7
+  8: («input_value» isa Main.Rematch2Tests.B && «where_2» := e.q3 && «where_2») => 8
+  9: («input_value» isa Main.Rematch2Tests.C && «where_3» := e.q4 && «where_3») => 9
+  10: («input_value» isa Main.Rematch2Tests.Foo && «input_value.x» := «input_value».x && «input_value.y» := «input_value».y && @ismatch(2, «input_value.y») && «where_4» := [x => «input_value.x»] f1(x) && «where_4») => 1
+  11: («input_value» isa Main.Rematch2Tests.Foo && «input_value.x» := «input_value».x && @ismatch(1, «input_value.x») && «input_value.y» := «input_value».y && «where_5» := [y => «input_value.y»] f2(y) && «where_5») => 2
+  12: («input_value» isa Main.Rematch2Tests.Foo && «input_value.x» := «input_value».x && «input_value.y» := «input_value».y && «where_4» := [x => «input_value.x»] f1(x) && «where_4» && «where_5» := [y => «input_value.y»] f2(y) && «where_5») => 3
+    TEST @ismatch(1, «input_value»)
     THEN: Node 2 (fall through)
     ELSE: Node 3
 Node 2
   1: true => 1
     MATCH 1 with value 1
 Node 3
-  2: («input_value» isa Main.Rematch2Tests.Foo && «input_value».x && «input_value».y && «input_value.y» == [x => «input_value.x»] x) => 2
+  2: («input_value» isa Main.Rematch2Tests.Foo && «input_value.x» := «input_value».x && «input_value.y» := «input_value».y && isequal([x => «input_value.x»] x, «input_value.y»)) => 2
   3: «input_value» isa Main.Rematch2Tests.D => 3
-  4: («input_value» isa AbstractArray && length(«input_value») && «length(input_value)» >= 2 && «input_value»[2:(length(«input_value»)-1)]) => [y => «input_value[2:(length-1)]»] y
-  5: («input_value» isa Tuple && length(«input_value») && «length(input_value)» >= 2 && «input_value»[-1] && (e).q1 && «where_0») => [z => «input_value[-1]»] z
-  6: («input_value» == 6 || «input_value» == 7) => 6
-  7: («input_value» isa Main.Rematch2Tests.A && (e).q2 && «where_1») => 7
-  8: («input_value» isa Main.Rematch2Tests.B && (e).q3 && «where_2») => 8
-  9: («input_value» isa Main.Rematch2Tests.C && (e).q4 && «where_3») => 9
-  10: («input_value» isa Main.Rematch2Tests.Foo && «input_value».x && «input_value».y && «input_value.y» == 2 && [x => «input_value.x»] (f1)(x) && «where_4») => 1
-  11: («input_value» isa Main.Rematch2Tests.Foo && «input_value».x && «input_value.x» == 1 && «input_value».y && [y => «input_value.y»] (f2)(y) && «where_5») => 2
-  12: («input_value» isa Main.Rematch2Tests.Foo && «input_value».x && «input_value».y && [x => «input_value.x»] (f1)(x) && «where_4» && [y => «input_value.y»] (f2)(y) && «where_5») => 3
+  4: («input_value» isa AbstractArray && «length(input_value)» := length(«input_value») && «length(input_value)» >= 2 && «input_value[2:(length-1)]» := «input_value»[2:(length(«input_value»)-1)]) => [y => «input_value[2:(length-1)]»] y
+  5: («input_value» isa Tuple && «length(input_value)» := length(«input_value») && «length(input_value)» >= 2 && «input_value[-1]» := «input_value»[-1] && «where_0» := e.q1 && «where_0») => [z => «input_value[-1]»] z
+  6: (@ismatch(6, «input_value») || @ismatch(7, «input_value»)) => 6
+  7: («input_value» isa Main.Rematch2Tests.A && «where_1» := e.q2 && «where_1») => 7
+  8: («input_value» isa Main.Rematch2Tests.B && «where_2» := e.q3 && «where_2») => 8
+  9: («input_value» isa Main.Rematch2Tests.C && «where_3» := e.q4 && «where_3») => 9
+  10: («input_value» isa Main.Rematch2Tests.Foo && «input_value.x» := «input_value».x && «input_value.y» := «input_value».y && @ismatch(2, «input_value.y») && «where_4» := [x => «input_value.x»] f1(x) && «where_4») => 1
+  11: («input_value» isa Main.Rematch2Tests.Foo && «input_value.x» := «input_value».x && @ismatch(1, «input_value.x») && «input_value.y» := «input_value».y && «where_5» := [y => «input_value.y»] f2(y) && «where_5») => 2
+  12: («input_value» isa Main.Rematch2Tests.Foo && «input_value.x» := «input_value».x && «input_value.y» := «input_value».y && «where_4» := [x => «input_value.x»] f1(x) && «where_4» && «where_5» := [y => «input_value.y»] f2(y) && «where_5») => 3
     TEST «input_value» isa Main.Rematch2Tests.Foo
     THEN: Node 4 (fall through)
     ELSE: Node 26
 Node 4
-  2: («input_value».x && «input_value».y && «input_value.y» == [x => «input_value.x»] x) => 2
-  6: («input_value» == 6 || «input_value» == 7) => 6
-  10: («input_value».x && «input_value».y && «input_value.y» == 2 && [x => «input_value.x»] (f1)(x) && «where_4») => 1
-  11: («input_value».x && «input_value.x» == 1 && «input_value».y && [y => «input_value.y»] (f2)(y) && «where_5») => 2
-  12: («input_value».x && «input_value».y && [x => «input_value.x»] (f1)(x) && «where_4» && [y => «input_value.y»] (f2)(y) && «where_5») => 3
+  2: («input_value.x» := «input_value».x && «input_value.y» := «input_value».y && isequal([x => «input_value.x»] x, «input_value.y»)) => 2
+  6: (@ismatch(6, «input_value») || @ismatch(7, «input_value»)) => 6
+  10: («input_value.x» := «input_value».x && «input_value.y» := «input_value».y && @ismatch(2, «input_value.y») && «where_4» := [x => «input_value.x»] f1(x) && «where_4») => 1
+  11: («input_value.x» := «input_value».x && @ismatch(1, «input_value.x») && «input_value.y» := «input_value».y && «where_5» := [y => «input_value.y»] f2(y) && «where_5») => 2
+  12: («input_value.x» := «input_value».x && «input_value.y» := «input_value».y && «where_4» := [x => «input_value.x»] f1(x) && «where_4» && «where_5» := [y => «input_value.y»] f2(y) && «where_5») => 3
     FETCH «input_value.x» := «input_value».x
     NEXT: Node 5 (fall through)
 Node 5
-  2: («input_value».y && «input_value.y» == [x => «input_value.x»] x) => 2
-  6: («input_value» == 6 || «input_value» == 7) => 6
-  10: («input_value».y && «input_value.y» == 2 && [x => «input_value.x»] (f1)(x) && «where_4») => 1
-  11: («input_value.x» == 1 && «input_value».y && [y => «input_value.y»] (f2)(y) && «where_5») => 2
-  12: («input_value».y && [x => «input_value.x»] (f1)(x) && «where_4» && [y => «input_value.y»] (f2)(y) && «where_5») => 3
+  2: («input_value.y» := «input_value».y && isequal([x => «input_value.x»] x, «input_value.y»)) => 2
+  6: (@ismatch(6, «input_value») || @ismatch(7, «input_value»)) => 6
+  10: («input_value.y» := «input_value».y && @ismatch(2, «input_value.y») && «where_4» := [x => «input_value.x»] f1(x) && «where_4») => 1
+  11: (@ismatch(1, «input_value.x») && «input_value.y» := «input_value».y && «where_5» := [y => «input_value.y»] f2(y) && «where_5») => 2
+  12: («input_value.y» := «input_value».y && «where_4» := [x => «input_value.x»] f1(x) && «where_4» && «where_5» := [y => «input_value.y»] f2(y) && «where_5») => 3
     FETCH «input_value.y» := «input_value».y
     NEXT: Node 6 (fall through)
 Node 6
-  2: «input_value.y» == [x => «input_value.x»] x => 2
-  6: («input_value» == 6 || «input_value» == 7) => 6
-  10: («input_value.y» == 2 && [x => «input_value.x»] (f1)(x) && «where_4») => 1
-  11: («input_value.x» == 1 && [y => «input_value.y»] (f2)(y) && «where_5») => 2
-  12: ([x => «input_value.x»] (f1)(x) && «where_4» && [y => «input_value.y»] (f2)(y) && «where_5») => 3
-    TEST «input_value.y» == [x => «input_value.x»] x
+  2: isequal([x => «input_value.x»] x, «input_value.y») => 2
+  6: (@ismatch(6, «input_value») || @ismatch(7, «input_value»)) => 6
+  10: (@ismatch(2, «input_value.y») && «where_4» := [x => «input_value.x»] f1(x) && «where_4») => 1
+  11: (@ismatch(1, «input_value.x») && «where_5» := [y => «input_value.y»] f2(y) && «where_5») => 2
+  12: («where_4» := [x => «input_value.x»] f1(x) && «where_4» && «where_5» := [y => «input_value.y»] f2(y) && «where_5») => 3
+    TEST isequal([x => «input_value.x»] x, «input_value.y»)
     THEN: Node 7 (fall through)
     ELSE: Node 8
 Node 7
   2: true => 2
     MATCH 2 with value 2
 Node 8
-  6: («input_value» == 6 || «input_value» == 7) => 6
-  10: («input_value.y» == 2 && [x => «input_value.x»] (f1)(x) && «where_4») => 1
-  11: («input_value.x» == 1 && [y => «input_value.y»] (f2)(y) && «where_5») => 2
-  12: ([x => «input_value.x»] (f1)(x) && «where_4» && [y => «input_value.y»] (f2)(y) && «where_5») => 3
-    TEST «input_value» == 6
+  6: (@ismatch(6, «input_value») || @ismatch(7, «input_value»)) => 6
+  10: (@ismatch(2, «input_value.y») && «where_4» := [x => «input_value.x»] f1(x) && «where_4») => 1
+  11: (@ismatch(1, «input_value.x») && «where_5» := [y => «input_value.y»] f2(y) && «where_5») => 2
+  12: («where_4» := [x => «input_value.x»] f1(x) && «where_4» && «where_5» := [y => «input_value.y»] f2(y) && «where_5») => 3
+    TEST @ismatch(6, «input_value»)
     THEN: Node 44
     ELSE: Node 9
 Node 9
-  6: «input_value» == 7 => 6
-  10: («input_value.y» == 2 && [x => «input_value.x»] (f1)(x) && «where_4») => 1
-  11: («input_value.x» == 1 && [y => «input_value.y»] (f2)(y) && «where_5») => 2
-  12: ([x => «input_value.x»] (f1)(x) && «where_4» && [y => «input_value.y»] (f2)(y) && «where_5») => 3
-    TEST «input_value» == 7
+  6: @ismatch(7, «input_value») => 6
+  10: (@ismatch(2, «input_value.y») && «where_4» := [x => «input_value.x»] f1(x) && «where_4») => 1
+  11: (@ismatch(1, «input_value.x») && «where_5» := [y => «input_value.y»] f2(y) && «where_5») => 2
+  12: («where_4» := [x => «input_value.x»] f1(x) && «where_4» && «where_5» := [y => «input_value.y»] f2(y) && «where_5») => 3
+    TEST @ismatch(7, «input_value»)
     THEN: Node 44
     ELSE: Node 10
 Node 10
-  10: («input_value.y» == 2 && [x => «input_value.x»] (f1)(x) && «where_4») => 1
-  11: («input_value.x» == 1 && [y => «input_value.y»] (f2)(y) && «where_5») => 2
-  12: ([x => «input_value.x»] (f1)(x) && «where_4» && [y => «input_value.y»] (f2)(y) && «where_5») => 3
-    TEST «input_value.y» == 2
+  10: (@ismatch(2, «input_value.y») && «where_4» := [x => «input_value.x»] f1(x) && «where_4») => 1
+  11: (@ismatch(1, «input_value.x») && «where_5» := [y => «input_value.y»] f2(y) && «where_5») => 2
+  12: («where_4» := [x => «input_value.x»] f1(x) && «where_4» && «where_5» := [y => «input_value.y»] f2(y) && «where_5») => 3
+    TEST @ismatch(2, «input_value.y»)
     THEN: Node 11 (fall through)
     ELSE: Node 17
 Node 11
-  10: ([x => «input_value.x»] (f1)(x) && «where_4») => 1
-  11: («input_value.x» == 1 && [y => «input_value.y»] (f2)(y) && «where_5») => 2
-  12: ([x => «input_value.x»] (f1)(x) && «where_4» && [y => «input_value.y»] (f2)(y) && «where_5») => 3
-    FETCH «where_4» := [x => «input_value.x»] (f1)(x)
+  10: («where_4» := [x => «input_value.x»] f1(x) && «where_4») => 1
+  11: (@ismatch(1, «input_value.x») && «where_5» := [y => «input_value.y»] f2(y) && «where_5») => 2
+  12: («where_4» := [x => «input_value.x»] f1(x) && «where_4» && «where_5» := [y => «input_value.y»] f2(y) && «where_5») => 3
+    FETCH «where_4» := [x => «input_value.x»] f1(x)
     NEXT: Node 12 (fall through)
 Node 12
   10: «where_4» => 1
-  11: («input_value.x» == 1 && [y => «input_value.y»] (f2)(y) && «where_5») => 2
-  12: («where_4» && [y => «input_value.y»] (f2)(y) && «where_5») => 3
+  11: (@ismatch(1, «input_value.x») && «where_5» := [y => «input_value.y»] f2(y) && «where_5») => 2
+  12: («where_4» && «where_5» := [y => «input_value.y»] f2(y) && «where_5») => 3
     TEST «where_4»
     THEN: Node 13 (fall through)
     ELSE: Node 14
@@ -132,13 +132,13 @@ Node 13
   10: true => 1
     MATCH 10 with value 1
 Node 14
-  11: («input_value.x» == 1 && [y => «input_value.y»] (f2)(y) && «where_5») => 2
-    TEST «input_value.x» == 1
+  11: (@ismatch(1, «input_value.x») && «where_5» := [y => «input_value.y»] f2(y) && «where_5») => 2
+    TEST @ismatch(1, «input_value.x»)
     THEN: Node 15 (fall through)
     ELSE: Node 57
 Node 15
-  11: ([y => «input_value.y»] (f2)(y) && «where_5») => 2
-    FETCH «where_5» := [y => «input_value.y»] (f2)(y)
+  11: («where_5» := [y => «input_value.y»] f2(y) && «where_5») => 2
+    FETCH «where_5» := [y => «input_value.y»] f2(y)
     NEXT: Node 16 (fall through)
 Node 16
   11: «where_5» => 2
@@ -146,19 +146,19 @@ Node 16
     THEN: Node 20
     ELSE: Node 57
 Node 17
-  11: («input_value.x» == 1 && [y => «input_value.y»] (f2)(y) && «where_5») => 2
-  12: ([x => «input_value.x»] (f1)(x) && «where_4» && [y => «input_value.y»] (f2)(y) && «where_5») => 3
-    TEST «input_value.x» == 1
+  11: (@ismatch(1, «input_value.x») && «where_5» := [y => «input_value.y»] f2(y) && «where_5») => 2
+  12: («where_4» := [x => «input_value.x»] f1(x) && «where_4» && «where_5» := [y => «input_value.y»] f2(y) && «where_5») => 3
+    TEST @ismatch(1, «input_value.x»)
     THEN: Node 18 (fall through)
     ELSE: Node 21
 Node 18
-  11: ([y => «input_value.y»] (f2)(y) && «where_5») => 2
-  12: ([x => «input_value.x»] (f1)(x) && «where_4» && [y => «input_value.y»] (f2)(y) && «where_5») => 3
-    FETCH «where_5» := [y => «input_value.y»] (f2)(y)
+  11: («where_5» := [y => «input_value.y»] f2(y) && «where_5») => 2
+  12: («where_4» := [x => «input_value.x»] f1(x) && «where_4» && «where_5» := [y => «input_value.y»] f2(y) && «where_5») => 3
+    FETCH «where_5» := [y => «input_value.y»] f2(y)
     NEXT: Node 19 (fall through)
 Node 19
   11: «where_5» => 2
-  12: ([x => «input_value.x»] (f1)(x) && «where_4» && «where_5») => 3
+  12: («where_4» := [x => «input_value.x»] f1(x) && «where_4» && «where_5») => 3
     TEST «where_5»
     THEN: Node 20 (fall through)
     ELSE: Node 57
@@ -166,17 +166,17 @@ Node 20
   11: true => 2
     MATCH 11 with value 2
 Node 21
-  12: ([x => «input_value.x»] (f1)(x) && «where_4» && [y => «input_value.y»] (f2)(y) && «where_5») => 3
-    FETCH «where_4» := [x => «input_value.x»] (f1)(x)
+  12: («where_4» := [x => «input_value.x»] f1(x) && «where_4» && «where_5» := [y => «input_value.y»] f2(y) && «where_5») => 3
+    FETCH «where_4» := [x => «input_value.x»] f1(x)
     NEXT: Node 22 (fall through)
 Node 22
-  12: («where_4» && [y => «input_value.y»] (f2)(y) && «where_5») => 3
+  12: («where_4» && «where_5» := [y => «input_value.y»] f2(y) && «where_5») => 3
     TEST «where_4»
     THEN: Node 23 (fall through)
     ELSE: Node 57
 Node 23
-  12: ([y => «input_value.y»] (f2)(y) && «where_5») => 3
-    FETCH «where_5» := [y => «input_value.y»] (f2)(y)
+  12: («where_5» := [y => «input_value.y»] f2(y) && «where_5») => 3
+    FETCH «where_5» := [y => «input_value.y»] f2(y)
     NEXT: Node 24 (fall through)
 Node 24
   12: «where_5» => 3
@@ -188,12 +188,12 @@ Node 25
     MATCH 12 with value 3
 Node 26
   3: «input_value» isa Main.Rematch2Tests.D => 3
-  4: («input_value» isa AbstractArray && length(«input_value») && «length(input_value)» >= 2 && «input_value»[2:(length(«input_value»)-1)]) => [y => «input_value[2:(length-1)]»] y
-  5: («input_value» isa Tuple && length(«input_value») && «length(input_value)» >= 2 && «input_value»[-1] && (e).q1 && «where_0») => [z => «input_value[-1]»] z
-  6: («input_value» == 6 || «input_value» == 7) => 6
-  7: («input_value» isa Main.Rematch2Tests.A && (e).q2 && «where_1») => 7
-  8: («input_value» isa Main.Rematch2Tests.B && (e).q3 && «where_2») => 8
-  9: («input_value» isa Main.Rematch2Tests.C && (e).q4 && «where_3») => 9
+  4: («input_value» isa AbstractArray && «length(input_value)» := length(«input_value») && «length(input_value)» >= 2 && «input_value[2:(length-1)]» := «input_value»[2:(length(«input_value»)-1)]) => [y => «input_value[2:(length-1)]»] y
+  5: («input_value» isa Tuple && «length(input_value)» := length(«input_value») && «length(input_value)» >= 2 && «input_value[-1]» := «input_value»[-1] && «where_0» := e.q1 && «where_0») => [z => «input_value[-1]»] z
+  6: (@ismatch(6, «input_value») || @ismatch(7, «input_value»)) => 6
+  7: («input_value» isa Main.Rematch2Tests.A && «where_1» := e.q2 && «where_1») => 7
+  8: («input_value» isa Main.Rematch2Tests.B && «where_2» := e.q3 && «where_2») => 8
+  9: («input_value» isa Main.Rematch2Tests.C && «where_3» := e.q4 && «where_3») => 9
     TEST «input_value» isa Main.Rematch2Tests.D
     THEN: Node 27 (fall through)
     ELSE: Node 28
@@ -201,23 +201,23 @@ Node 27
   3: true => 3
     MATCH 3 with value 3
 Node 28
-  4: («input_value» isa AbstractArray && length(«input_value») && «length(input_value)» >= 2 && «input_value»[2:(length(«input_value»)-1)]) => [y => «input_value[2:(length-1)]»] y
-  5: («input_value» isa Tuple && length(«input_value») && «length(input_value)» >= 2 && «input_value»[-1] && (e).q1 && «where_0») => [z => «input_value[-1]»] z
-  6: («input_value» == 6 || «input_value» == 7) => 6
-  7: («input_value» isa Main.Rematch2Tests.A && (e).q2 && «where_1») => 7
-  8: («input_value» isa Main.Rematch2Tests.B && (e).q3 && «where_2») => 8
-  9: («input_value» isa Main.Rematch2Tests.C && (e).q4 && «where_3») => 9
+  4: («input_value» isa AbstractArray && «length(input_value)» := length(«input_value») && «length(input_value)» >= 2 && «input_value[2:(length-1)]» := «input_value»[2:(length(«input_value»)-1)]) => [y => «input_value[2:(length-1)]»] y
+  5: («input_value» isa Tuple && «length(input_value)» := length(«input_value») && «length(input_value)» >= 2 && «input_value[-1]» := «input_value»[-1] && «where_0» := e.q1 && «where_0») => [z => «input_value[-1]»] z
+  6: (@ismatch(6, «input_value») || @ismatch(7, «input_value»)) => 6
+  7: («input_value» isa Main.Rematch2Tests.A && «where_1» := e.q2 && «where_1») => 7
+  8: («input_value» isa Main.Rematch2Tests.B && «where_2» := e.q3 && «where_2») => 8
+  9: («input_value» isa Main.Rematch2Tests.C && «where_3» := e.q4 && «where_3») => 9
     TEST «input_value» isa AbstractArray
     THEN: Node 29 (fall through)
     ELSE: Node 33
 Node 29
-  4: (length(«input_value») && «length(input_value)» >= 2 && «input_value»[2:(length(«input_value»)-1)]) => [y => «input_value[2:(length-1)]»] y
-  6: («input_value» == 6 || «input_value» == 7) => 6
+  4: («length(input_value)» := length(«input_value») && «length(input_value)» >= 2 && «input_value[2:(length-1)]» := «input_value»[2:(length(«input_value»)-1)]) => [y => «input_value[2:(length-1)]»] y
+  6: (@ismatch(6, «input_value») || @ismatch(7, «input_value»)) => 6
     FETCH «length(input_value)» := length(«input_value»)
     NEXT: Node 30 (fall through)
 Node 30
-  4: («length(input_value)» >= 2 && «input_value»[2:(length(«input_value»)-1)]) => [y => «input_value[2:(length-1)]»] y
-  6: («input_value» == 6 || «input_value» == 7) => 6
+  4: («length(input_value)» >= 2 && «input_value[2:(length-1)]» := «input_value»[2:(length(«input_value»)-1)]) => [y => «input_value[2:(length-1)]»] y
+  6: (@ismatch(6, «input_value») || @ismatch(7, «input_value»)) => 6
     TEST «length(input_value)» >= 2
     THEN: Node 31 (fall through)
     ELSE: Node 40
@@ -229,38 +229,38 @@ Node 32
   4: true => [y => «input_value[2:(length-1)]»] y
     MATCH 4 with value [y => «input_value[2:(length-1)]»] y
 Node 33
-  5: («input_value» isa Tuple && length(«input_value») && «length(input_value)» >= 2 && «input_value»[-1] && (e).q1 && «where_0») => [z => «input_value[-1]»] z
-  6: («input_value» == 6 || «input_value» == 7) => 6
-  7: («input_value» isa Main.Rematch2Tests.A && (e).q2 && «where_1») => 7
-  8: («input_value» isa Main.Rematch2Tests.B && (e).q3 && «where_2») => 8
-  9: («input_value» isa Main.Rematch2Tests.C && (e).q4 && «where_3») => 9
+  5: («input_value» isa Tuple && «length(input_value)» := length(«input_value») && «length(input_value)» >= 2 && «input_value[-1]» := «input_value»[-1] && «where_0» := e.q1 && «where_0») => [z => «input_value[-1]»] z
+  6: (@ismatch(6, «input_value») || @ismatch(7, «input_value»)) => 6
+  7: («input_value» isa Main.Rematch2Tests.A && «where_1» := e.q2 && «where_1») => 7
+  8: («input_value» isa Main.Rematch2Tests.B && «where_2» := e.q3 && «where_2») => 8
+  9: («input_value» isa Main.Rematch2Tests.C && «where_3» := e.q4 && «where_3») => 9
     TEST «input_value» isa Tuple
     THEN: Node 34 (fall through)
     ELSE: Node 42
 Node 34
-  5: (length(«input_value») && «length(input_value)» >= 2 && «input_value»[-1] && (e).q1 && «where_0») => [z => «input_value[-1]»] z
-  6: («input_value» == 6 || «input_value» == 7) => 6
+  5: («length(input_value)» := length(«input_value») && «length(input_value)» >= 2 && «input_value[-1]» := «input_value»[-1] && «where_0» := e.q1 && «where_0») => [z => «input_value[-1]»] z
+  6: (@ismatch(6, «input_value») || @ismatch(7, «input_value»)) => 6
     FETCH «length(input_value)» := length(«input_value»)
     NEXT: Node 35 (fall through)
 Node 35
-  5: («length(input_value)» >= 2 && «input_value»[-1] && (e).q1 && «where_0») => [z => «input_value[-1]»] z
-  6: («input_value» == 6 || «input_value» == 7) => 6
+  5: («length(input_value)» >= 2 && «input_value[-1]» := «input_value»[-1] && «where_0» := e.q1 && «where_0») => [z => «input_value[-1]»] z
+  6: (@ismatch(6, «input_value») || @ismatch(7, «input_value»)) => 6
     TEST «length(input_value)» >= 2
     THEN: Node 36 (fall through)
     ELSE: Node 40
 Node 36
-  5: («input_value»[-1] && (e).q1 && «where_0») => [z => «input_value[-1]»] z
-  6: («input_value» == 6 || «input_value» == 7) => 6
+  5: («input_value[-1]» := «input_value»[-1] && «where_0» := e.q1 && «where_0») => [z => «input_value[-1]»] z
+  6: (@ismatch(6, «input_value») || @ismatch(7, «input_value»)) => 6
     FETCH «input_value[-1]» := «input_value»[-1]
     NEXT: Node 37 (fall through)
 Node 37
-  5: ((e).q1 && «where_0») => [z => «input_value[-1]»] z
-  6: («input_value» == 6 || «input_value» == 7) => 6
-    FETCH «where_0» := (e).q1
+  5: («where_0» := e.q1 && «where_0») => [z => «input_value[-1]»] z
+  6: (@ismatch(6, «input_value») || @ismatch(7, «input_value»)) => 6
+    FETCH «where_0» := e.q1
     NEXT: Node 38 (fall through)
 Node 38
   5: «where_0» => [z => «input_value[-1]»] z
-  6: («input_value» == 6 || «input_value» == 7) => 6
+  6: (@ismatch(6, «input_value») || @ismatch(7, «input_value»)) => 6
     TEST «where_0»
     THEN: Node 39 (fall through)
     ELSE: Node 40
@@ -268,51 +268,51 @@ Node 39
   5: true => [z => «input_value[-1]»] z
     MATCH 5 with value [z => «input_value[-1]»] z
 Node 40
-  6: («input_value» == 6 || «input_value» == 7) => 6
-    TEST «input_value» == 6
+  6: (@ismatch(6, «input_value») || @ismatch(7, «input_value»)) => 6
+    TEST @ismatch(6, «input_value»)
     THEN: Node 44
     ELSE: Node 41
 Node 41
-  6: «input_value» == 7 => 6
-    TEST «input_value» == 7
+  6: @ismatch(7, «input_value») => 6
+    TEST @ismatch(7, «input_value»)
     THEN: Node 44
     ELSE: Node 57
 Node 42
-  6: («input_value» == 6 || «input_value» == 7) => 6
-  7: («input_value» isa Main.Rematch2Tests.A && (e).q2 && «where_1») => 7
-  8: («input_value» isa Main.Rematch2Tests.B && (e).q3 && «where_2») => 8
-  9: («input_value» isa Main.Rematch2Tests.C && (e).q4 && «where_3») => 9
-    TEST «input_value» == 6
+  6: (@ismatch(6, «input_value») || @ismatch(7, «input_value»)) => 6
+  7: («input_value» isa Main.Rematch2Tests.A && «where_1» := e.q2 && «where_1») => 7
+  8: («input_value» isa Main.Rematch2Tests.B && «where_2» := e.q3 && «where_2») => 8
+  9: («input_value» isa Main.Rematch2Tests.C && «where_3» := e.q4 && «where_3») => 9
+    TEST @ismatch(6, «input_value»)
     THEN: Node 44
     ELSE: Node 43
 Node 43
-  6: «input_value» == 7 => 6
-  7: («input_value» isa Main.Rematch2Tests.A && (e).q2 && «where_1») => 7
-  8: («input_value» isa Main.Rematch2Tests.B && (e).q3 && «where_2») => 8
-  9: («input_value» isa Main.Rematch2Tests.C && (e).q4 && «where_3») => 9
-    TEST «input_value» == 7
+  6: @ismatch(7, «input_value») => 6
+  7: («input_value» isa Main.Rematch2Tests.A && «where_1» := e.q2 && «where_1») => 7
+  8: («input_value» isa Main.Rematch2Tests.B && «where_2» := e.q3 && «where_2») => 8
+  9: («input_value» isa Main.Rematch2Tests.C && «where_3» := e.q4 && «where_3») => 9
+    TEST @ismatch(7, «input_value»)
     THEN: Node 44 (fall through)
     ELSE: Node 45
 Node 44
   6: true => 6
     MATCH 6 with value 6
 Node 45
-  7: («input_value» isa Main.Rematch2Tests.A && (e).q2 && «where_1») => 7
-  8: («input_value» isa Main.Rematch2Tests.B && (e).q3 && «where_2») => 8
-  9: («input_value» isa Main.Rematch2Tests.C && (e).q4 && «where_3») => 9
+  7: («input_value» isa Main.Rematch2Tests.A && «where_1» := e.q2 && «where_1») => 7
+  8: («input_value» isa Main.Rematch2Tests.B && «where_2» := e.q3 && «where_2») => 8
+  9: («input_value» isa Main.Rematch2Tests.C && «where_3» := e.q4 && «where_3») => 9
     TEST «input_value» isa Main.Rematch2Tests.A
     THEN: Node 46 (fall through)
     ELSE: Node 57
 Node 46
-  7: ((e).q2 && «where_1») => 7
-  8: («input_value» isa Main.Rematch2Tests.B && (e).q3 && «where_2») => 8
-  9: («input_value» isa Main.Rematch2Tests.C && (e).q4 && «where_3») => 9
-    FETCH «where_1» := (e).q2
+  7: («where_1» := e.q2 && «where_1») => 7
+  8: («input_value» isa Main.Rematch2Tests.B && «where_2» := e.q3 && «where_2») => 8
+  9: («input_value» isa Main.Rematch2Tests.C && «where_3» := e.q4 && «where_3») => 9
+    FETCH «where_1» := e.q2
     NEXT: Node 47 (fall through)
 Node 47
   7: «where_1» => 7
-  8: («input_value» isa Main.Rematch2Tests.B && (e).q3 && «where_2») => 8
-  9: («input_value» isa Main.Rematch2Tests.C && (e).q4 && «where_3») => 9
+  8: («input_value» isa Main.Rematch2Tests.B && «where_2» := e.q3 && «where_2») => 8
+  9: («input_value» isa Main.Rematch2Tests.C && «where_3» := e.q4 && «where_3») => 9
     TEST «where_1»
     THEN: Node 48 (fall through)
     ELSE: Node 49
@@ -320,14 +320,14 @@ Node 48
   7: true => 7
     MATCH 7 with value 7
 Node 49
-  8: («input_value» isa Main.Rematch2Tests.B && (e).q3 && «where_2») => 8
-  9: («input_value» isa Main.Rematch2Tests.C && (e).q4 && «where_3») => 9
+  8: («input_value» isa Main.Rematch2Tests.B && «where_2» := e.q3 && «where_2») => 8
+  9: («input_value» isa Main.Rematch2Tests.C && «where_3» := e.q4 && «where_3») => 9
     TEST «input_value» isa Main.Rematch2Tests.B
     THEN: Node 50 (fall through)
     ELSE: Node 53
 Node 50
-  8: ((e).q3 && «where_2») => 8
-    FETCH «where_2» := (e).q3
+  8: («where_2» := e.q3 && «where_2») => 8
+    FETCH «where_2» := e.q3
     NEXT: Node 51 (fall through)
 Node 51
   8: «where_2» => 8
@@ -338,13 +338,13 @@ Node 52
   8: true => 8
     MATCH 8 with value 8
 Node 53
-  9: («input_value» isa Main.Rematch2Tests.C && (e).q4 && «where_3») => 9
+  9: («input_value» isa Main.Rematch2Tests.C && «where_3» := e.q4 && «where_3») => 9
     TEST «input_value» isa Main.Rematch2Tests.C
     THEN: Node 54 (fall through)
     ELSE: Node 57
 Node 54
-  9: ((e).q4 && «where_3») => 9
-    FETCH «where_3» := (e).q4
+  9: («where_3» := e.q4 && «where_3») => 9
+    FETCH «where_3» := e.q4
     NEXT: Node 55 (fall through)
 Node 55
   9: «where_3» => 9
@@ -355,7 +355,7 @@ Node 56
   9: true => 9
     MATCH 9 with value 9
 Node 57
-    FAIL (throw)((Rematch2.MatchFailure)(«input_value»))
+    FAIL (throw)((Rematch2.MatchFailure)(var"«input_value»"))
 end # of automaton
 """
 @testset "Tests for node coverage" begin
@@ -437,6 +437,9 @@ end # of automaton
         #     return esc(:(x => value))
         # end
         @test (@match2 :x begin
+            @match_case pattern 1
+        end) == 1
+        @test (@match :x begin
             @match_case pattern 1
         end) == 1
     end

--- a/test/coverage.jl
+++ b/test/coverage.jl
@@ -404,6 +404,11 @@ end # of automaton
         binder = Rematch2.BinderContext(@__MODULE__)
         @test_throws ErrorException Rematch2.code(trash)
         @test_throws ErrorException Rematch2.code(trash, binder)
+        @test_throws ErrorException Rematch2.pretty(stdout, trash)
+        @test_throws LoadError @eval begin
+            x=123
+            Rematch2.@ismatch x (1:(2+3))
+        end
     end
 
     function f300(x::T) where { T }

--- a/test/nontrivial.jl
+++ b/test/nontrivial.jl
@@ -88,8 +88,10 @@ macro simplify_top(n, mac)
     end)
 end
 
-@simplify_top(1, Rematch2.@match(expr))
-@simplify_top(2, Rematch2.@match2(expr))
+# @simplify_top(0, Match.@match(expr))
+# @simplify_top(1, Rematch.@match(expr))
+@simplify_top(2, Rematch2.@match(expr))
+@simplify_top(3, Rematch2.@match2(expr))
 
 @testset "Check some complex cases" begin
 
@@ -127,31 +129,40 @@ end
     expected = Sub(Const(-63.0), Mul(Const(3.0), x))
 
     @testset "Check some simple cases" begin
-        @test simplify_top1(Sub(x, Neg(y))) == Add(x, y)
         @test simplify_top2(Sub(x, Neg(y))) == Add(x, y)
-        @test simplify_top1(Add(x, Neg(y))) == Sub(x, y)
+        @test simplify_top3(Sub(x, Neg(y))) == Add(x, y)
         @test simplify_top2(Add(x, Neg(y))) == Sub(x, y)
+        @test simplify_top3(Add(x, Neg(y))) == Sub(x, y)
     end
 
+    # dump(expr)
+    # dump(simplify0(expr))
+
     # @test simplify0(expr) == expected
-    @test simplify1(expr) == expected
+    # @test simplify1(expr) == expected
     @test simplify2(expr) == expected
+    @test simplify3(expr) == expected
 
     # function performance_test(expr::Expression)
-    #     GC.gc()
-    #     # println("===================== Rematch.@match")
-    #     # @time for i in 1:1000000
+    #     # GC.gc()
+    #     # println("===================== Match.@match")
+    #     # @time for i in 1:2000000
     #     #     simplify0(expr)
     #     # end
     #     GC.gc()
-    #     println("===================== Rematch2.@match")
-    #     @time for i in 1:1000000
+    #     println("===================== Rematch.@match")
+    #     @time for i in 1:2000000
     #         simplify1(expr)
     #     end
     #     GC.gc()
-    #     println("===================== Rematch2.@match2")
-    #     @time for i in 1:1000000
+    #     println("===================== Rematch2.@match")
+    #     @time for i in 1:2000000
     #         simplify2(expr)
+    #     end
+    #     GC.gc()
+    #     println("===================== Rematch2.@match2")
+    #     @time for i in 1:2000000
+    #         simplify3(expr)
     #     end
     #     GC.gc()
     # end

--- a/test/rematch.jl
+++ b/test/rematch.jl
@@ -4,7 +4,7 @@
 # expansion of the @match macro so we can use the known bindings
 # of types to generate more efficient node.
 
-@testset "@rematch tests" begin
+@testset "Rematch2.@match tests" begin
 
 @testset "Assignments in the value do not leak out" begin
     @match Foo(1, 2) begin
@@ -353,12 +353,12 @@ end
     end) == :ok
 
     # QuoteNodes
-    @test (@match :(:x) begin
-      :(:x) => :ok
-    end) == :ok
-    @test (@match :(:x+:y) begin
-      :(:x + :y) => :ok
-    end) == :ok
+    # @test (@match :(:x) begin
+    #   :(:x) => :ok
+    # end) == :ok
+    # @test (@match :(:x+:y) begin
+    #   :(:x + :y) => :ok
+    # end) == :ok
 end
 
 @testset "logical expressions with branches" begin
@@ -696,18 +696,33 @@ end
         @match n begin
             0      => "zero"
             1 || 2 => "one or two"
-            # TODO: support range patterns
-            # 3:10   => "three to ten"
+            3:10   => "three to ten"
             _      => "something else"
         end
     end
 
     @test num_match(0) == "zero"
     @test num_match(2) == "one or two"
-    # @test num_match(4) == "three to ten"
+    @test num_match(4) == "three to ten"
     @test num_match(12) == "something else"
     @test num_match("hi") == "something else"
     @test num_match('c') == "something else"
+
+    function char_match(c)
+        @match c begin
+            'A':'Z' => "uppercase"
+            'a':'z' => "lowercase"
+            '0':'9' => "number"
+            _       => "other"
+        end
+    end
+
+    @test char_match('M') == "uppercase"
+    @test char_match('n') == "lowercase"
+    @test char_match('8') == "number"
+    @test char_match(' ') == "other"
+    @test char_match("8") == "other"
+    @test char_match(8) == "other"
 
     # Interpolation of matches in quoted expressions
     test_interp(item) = @match item begin

--- a/test/rematch.jl
+++ b/test/rematch.jl
@@ -352,6 +352,12 @@ end
       v"1.2.0" => :ok
     end) == :ok
 
+    ###
+    ### We do not support `QuoteNode` or `Expr` in `@match` blocks like `Rematch.jl`.
+    ### There, they were treated as literals, but they could contain
+    ### interpolated expressions, which we would want to handle properly.
+    ### It would be nice to support some kind of pattern-matching on them.
+    ###
     # QuoteNodes
     # @test (@match :(:x) begin
     #   :(:x) => :ok

--- a/test/rematch2.jl
+++ b/test/rematch2.jl
@@ -856,6 +856,12 @@ end
       v"1.2.0" => :ok
     end) == :ok
 
+    ###
+    ### We do not support `QuoteNode` or `Expr` in `@match` blocks like `Rematch.jl`.
+    ### There, they were treated as literals, but they could contain
+    ### interpolated expressions, which we would want to handle properly.
+    ### It would be nice to support some kind of pattern-matching on them.
+    ###
     # QuoteNodes
     # @test (@match2 :(:x) begin
     #   :(:x) => :ok

--- a/test/rematch2.jl
+++ b/test/rematch2.jl
@@ -23,7 +23,18 @@ macro check_is_identifier(x::Symbol)
     true
 end
 
-@testset "@rematch2 tests" begin
+@testset "Rematch2.@match2 tests" begin
+
+@testset "test the simplest form of regex matches, which are supported by Match.jl" begin
+    function is_ipv4_address(s)
+        @match s begin
+            r"(\d+)\.(\d+)\.(\d+)\.(\d+)" => true
+            _ => false
+        end
+    end
+    @test is_ipv4_address("192.168.0.5")
+    @test !is_ipv4_address("www.gafter.com")
+end
 
 @testset "Check that `,if condition end` guards are parsed properly" begin
     x = true
@@ -755,6 +766,13 @@ end
         @test q == "changed"
     end
 
+    @testset "disallow lazy strings in patterns due to their support of interpolation" begin
+        z=3
+        @test_throws LoadError (@eval @match2 z begin
+            lazy"$(z)" => 1
+            _ => 0
+        end)
+    end
 end
 
 @testset "ensure we use `isequal` and not `==`" begin
@@ -839,12 +857,12 @@ end
     end) == :ok
 
     # QuoteNodes
-    @test (@match2 :(:x) begin
-      :(:x) => :ok
-    end) == :ok
-    @test (@match2 :(:x+:y) begin
-      :(:x + :y) => :ok
-    end) == :ok
+    # @test (@match2 :(:x) begin
+    #   :(:x) => :ok
+    # end) == :ok
+    # @test (@match2 :(:x+:y) begin
+    #   :(:x + :y) => :ok
+    # end) == :ok
 end
 
 @testset "logical expressions with branches" begin
@@ -1178,15 +1196,14 @@ end
         @match2 n begin
             0      => "zero"
             1 || 2 => "one or two"
-            # TODO: support range patterns
-            # 3:10   => "three to ten"
+            3:10   => "three to ten"
             _      => "something else"
         end
     end
 
     @test num_match(0) == "zero"
     @test num_match(2) == "one or two"
-    # @test num_match(4) == "three to ten"
+    @test num_match(4) == "three to ten"
     @test num_match(12) == "something else"
     @test num_match("hi") == "something else"
     @test num_match('c') == "something else"


### PR DESCRIPTION
* Remove support for quoted expressions as literal patterns.  It didn't work right, and it interferes with extensions to provide more clever introspection in the future.
* Changed from the use of `Base.isequal` to `Rematch2.ismatch` for compat with `Match.jl` and to add some flexibility (clients can override it for specific types).  Then implemented the usual suspects (default to isequal) and added support for ranges and regular expressions.
* Added more precise support for macros to support bignums, verbatim literals, version identifiers, and other string macros.
* Added support for a Symbol positional pattern (one parameter: its string form).
* Removed support for `Expr` that merely compared with the input using `isequel`.  This permits us to add perhaps more flexible expression matching in the future.
* Fixed a bug in Match.jl that `SubString`s will not match a regular expression.

This PR is built on top of #62.  That should be merged before this.
